### PR TITLE
Make flag display more consistent with country flags

### DIFF
--- a/extension/src/utils/flagHtml.ts
+++ b/extension/src/utils/flagHtml.ts
@@ -4,7 +4,7 @@ import { osuWorldUser } from "./osuWorld";
 import { addOrReplaceQueryParam } from "./utils";
 
 // Quotes needed for special characters
-const flagStyle = 'background-image: url("$flag"); background-size: contain';
+const flagStyle = 'background-image: url("$flag"); background-size: auto 100%';
 const marginLeftStyle = "margin-left: 4px";
 const flagStyleWithMargin = flagStyle + ";" + marginLeftStyle;
 const noFlag =


### PR DESCRIPTION
Changes `background-size` from `contain` to `auto 100%` which fills the height. Essentially the same as using `cover`, but without breaking smaller aspect ratio flags. Slight cropping occurs on flags wider than 1.39:1 but I think overall this improves the display enough for that to not matter.
![image](https://github.com/Cavitedev/osu-subdivide-nations/assets/57327918/8c802ea4-d09c-42f0-a8b1-5e469bb8a32f)

Not a perfect solution, as some flags do look a bit off with this on, such as Ohio, but maybe edge cases could manually be assigned an appropriate size (specify in the json?)
![image](https://github.com/Cavitedev/osu-subdivide-nations/assets/57327918/5edfe014-16cf-4b38-aada-07f966014798)

Maine for example is quite not wide enough so the edges still look off, but applying `cover` manually would make it look nice without cutting off anything important
![image](https://github.com/Cavitedev/osu-subdivide-nations/assets/57327918/a74a19e7-ec41-41d6-8f90-226e10e79a21)

