### PR TITLE
Make wiki page region flags rounded

### DIFF
--- a/extension/src/content-script/osu/flagHtml.ts
+++ b/extension/src/content-script/osu/flagHtml.ts
@@ -238,7 +238,7 @@ const addWikiPageFlag = async (
         flag = noFlag;
     }
 
-    flagElement.setAttribute("style", flagStyle.replace("$flag", flag) + ";margin-right: 4px;");
+    flagElement.setAttribute("style", flagStyle.replace("$flag", flag) + ";margin-right: 4px;border-radius: 2px;");
 
     const parent = item.parentElement!;
     parent.insertBefore(flagElement, item);


### PR DESCRIPTION
Simple `border-radius: 2px;` addition to match what the normal flags have as these do not seem to be rounded by default.